### PR TITLE
NI-2639 Fix issues from original plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 moodle-webservice_restjson
 ================================
 
+***This is a fork of [this plugin](https://github.com/wset/moodle-webservice_restjson) due to it no longer being maintained. This version of the plugin is not published to the moodle plugin directory and instead must be installed via zip upload.***
+
 REST webservice protocol based on the standard core REST webservice, but with added support for JSON & XML payloads
 and supports using HTTP ACCEPTS headers for determining response format.
 

--- a/simpleserver.php
+++ b/simpleserver.php
@@ -31,9 +31,9 @@ define('NO_DEBUG_DISPLAY', true);
 define('WS_SERVER', true);
 
 require('../../config.php');
-require_once("$CFG->dirroot/webservice/rest/locallib.php");
+require_once("$CFG->dirroot/webservice/restjson/locallib.php");
 
-if (!webservice_protocol_is_enabled('rest')) {
+if (!webservice_protocol_is_enabled('restjson')) {
     die;
 }
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2016021900;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2020021100;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2015050500;        // Requires this Moodle version
 $plugin->component = 'webservice_restjson'; // Full name of the plugin (used for diagnostics)
-$plugin->release   = '0.4 for Moodle 2.9+';
+$plugin->release   = '0.4.1 for Moodle 2.9+';


### PR DESCRIPTION
This webservice was originally copied from the _rest_ webservice which is built into Moodle. When it was being copied, some of the paths were not updated and so still point to the location of the original webservices's library. 
The first commit fixes an invalid path and also updates the check for ensuring the relevant webservice is enabled. The second commit updates the version number and readme

## More details on the invalid path fix
[This commit](https://github.com/Administrate/moodle-webservice_restjson/commit/00bda726440be3019a82e6cfbd11d97aa1cc6393#diff-c7b36e05b81cc4174a915d1bd510c758) shows the changes that the original plugin author made after cloning the built in _rest_ webservice. By looking at the changes made to _server.php_ and _simpleserver.php_ you can see that they have not updated the path to the local library in _simpleserver.php_  (look at LN34 of each file).
These files allow different ways of authenticating when using the same webservice but that is the only difference, and so both should import the same local library.